### PR TITLE
Fix: Mitsuba 3 support

### DIFF
--- a/pointflow_fig_colorful.py
+++ b/pointflow_fig_colorful.py
@@ -29,7 +29,7 @@ xml_head = \
         <sampler type="ldsampler">
             <integer name="sampleCount" value="256"/>
         </sampler>
-        <film type="ldrfilm">
+        <film type="hdrfilm">
             <integer name="width" value="1600"/>
             <integer name="height" value="1200"/>
             <rfilter type="gaussian"/>


### PR DESCRIPTION
Fix error: Plugin "ldrfilm" not found! for Mitsuba 3 renderer